### PR TITLE
allow a prefix to be specified when downloading access logs from S3 bucket

### DIFF
--- a/aws_s3_log_analyzer/dates.py
+++ b/aws_s3_log_analyzer/dates.py
@@ -2,14 +2,14 @@ from datetime import datetime, timedelta
 from pytz import UTC
 
 def date_range_to_days_list(start_date, end_date):
-  '''return list of the days between start date and end date'''
+  """return list of the days between start date and end date"""
   delta = end_date - start_date
   dates = [start_date + timedelta(days=i) for i in range(delta.days + 1)]
   days = [date.strftime("%Y-%m-%d") for date in dates]
   return days
 
 def string_to_utc_date(strx):
-  ''' convert date string of format 1990-01-01 01:01:01 to a datetime object, utc assumed '''
+  """convert date string of format 1990-01-01 01:01:01 to a datetime object, utc assumed"""
   if isinstance(strx, str):
     date = datetime.strptime(strx, '%Y-%m-%d %H:%M:%S')
     return date.replace(tzinfo=UTC)

--- a/aws_s3_log_analyzer/dates.py
+++ b/aws_s3_log_analyzer/dates.py
@@ -1,5 +1,12 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from pytz import UTC
+
+def date_range_to_days_list(start_date, end_date):
+  '''return list of the days between start date and end date'''
+  delta = end_date - start_date
+  dates = [start_date + timedelta(days=i) for i in range(delta.days + 1)]
+  days = [date.strftime("%Y-%m-%d") for date in dates]
+  return days
 
 def string_to_utc_date(strx):
   ''' convert date string of format 1990-01-01 01:01:01 to a datetime object, utc assumed '''

--- a/aws_s3_log_analyzer/files.py
+++ b/aws_s3_log_analyzer/files.py
@@ -5,7 +5,7 @@ import os
 from multiprocessing import Pool
 
 def files(dirx):
-  ''' recursively glob all files in dir '''
+  """recursively glob all files in dir"""
   globstr = dirx + '/**'
   return [
     path for path in glob.glob(globstr, recursive=True)
@@ -13,14 +13,14 @@ def files(dirx):
   ]
 
 def make_dirs(paths):
-  ''' create the directories named in paths '''
+  """create the directories named in paths"""
   for path in paths:
     dir_path = os.path.dirname(path)
     if not os.path.exists(dir_path):
       os.makedirs(dir_path)
 
 def read_files_in_dir(dirx):
-  ''' recursively read all files in dir '''
+  """recursively read all files in dir"""
   lines_of_all_files = []
   with Pool(1) as pool:
     for lines_of_one_file in pool.map(read_path, files(dirx)):
@@ -28,7 +28,7 @@ def read_files_in_dir(dirx):
   return lines_of_all_files
 
 def read_path(path):
-  ''' read path file or if it's a dir, all files in it '''
+  """read path file or if it's a dir, all files in it"""
   if os.path.isfile(path):
     with open(path, 'r') as reader:
       lines = reader.readlines()

--- a/aws_s3_log_analyzer/logs.py
+++ b/aws_s3_log_analyzer/logs.py
@@ -4,12 +4,12 @@ import pandas as pd
 from aws_s3_log_analyzer.files import read_path
 
 def clean_log(log):
-  ''' clean log into valid csv '''
+  """clean log into valid csv"""
   # replace brackets with quotes
   return log.replace('[', '"', 1).replace(']', '"', 1)
 
 def create_data_frame(logpath, fields):
-  ''' return dataframe containing the interested fields and date, from the logs '''
+  """return dataframe containing the interested fields and date, from the logs"""
   df = pd.read_csv('./data/s3_log_field_list.txt', sep=' ', header=None)
   columns = df[1].tolist()
   csv_rows = s3_logs_to_csv_rows(logpath)
@@ -20,7 +20,7 @@ def create_data_frame(logpath, fields):
   return df[fields + ['yyyy-mm-dd']]
 
 def s3_logs_to_csv_rows(logpath):
-  ''' convert s3 logs to csv rows '''
+  """convert s3 logs to csv rows"""
   rows = []
   for log in read_path(logpath):
     csv_reader = csv.reader([clean_log(log)], delimiter=' ')

--- a/aws_s3_log_analyzer/s3.py
+++ b/aws_s3_log_analyzer/s3.py
@@ -3,10 +3,10 @@ import os
 
 from aws_s3_log_analyzer.files import make_dirs
 
-def download(bucket, start_date, end_date, dest_dir):
+def download(bucket, prefix, start_date, end_date, dest_dir):
   ''' download s3 bucket keys that were last modified within date range '''
   client = boto3.client('s3')
-  [keys, keys_last_modified] = list_keys(client, bucket)
+  [keys, keys_last_modified] = list_keys(client, bucket, prefix)
   wanted_keys = keys_last_modified_in_range(
                   keys, keys_last_modified, start_date, end_date
                 )
@@ -32,13 +32,14 @@ def keys_last_modified_in_range(keys, keys_last_modified, start_date, end_date):
       keys_last_modified[index] <= end_date
   ]
 
-def list_keys(client, bucket):
-  ''' list all keys in s3 bucket '''
+def list_keys(client, bucket, prefix):
+  ''' list all keys in s3 bucket matching prefix '''
   keys = []
   keys_last_modified = []
   next_token = ''
   base_kwargs = {
-    'Bucket':bucket
+    'Bucket':bucket,
+    'Prefix':prefix
   }
   while next_token is not None:
     kwargs = base_kwargs.copy()

--- a/aws_s3_log_analyzer/s3.py
+++ b/aws_s3_log_analyzer/s3.py
@@ -5,7 +5,7 @@ from aws_s3_log_analyzer.dates import date_range_to_days_list
 from aws_s3_log_analyzer.files import make_dirs
 
 def download_access_logs(bucket, prefix, start_date, end_date, dest_dir):
-  ''' download s3 access logs that were last modified within date range '''
+  """download s3 access logs that were last modified within date range"""
   client = boto3.client('s3')
   # when access log files span years, listing them all take a long time.
   # since we have start and end dates, and that access log files have dates in their names.
@@ -19,19 +19,19 @@ def download_access_logs(bucket, prefix, start_date, end_date, dest_dir):
   download_keys(client, bucket, filtered_keys, dest_dir)
 
 def download_keys(client, bucket, keys, dest_dir):
-  ''' download s3 bucket keys '''
+  """download s3 bucket keys"""
   keys_and_paths = map_keys_to_paths(keys, dest_dir)
   paths = list(keys_and_paths.values())
   make_dirs(paths)
   download_keys_to_paths(client, bucket, keys_and_paths)
 
 def download_keys_to_paths(client, bucket, keys_and_paths):
-  ''' download s3 bucket keys to specified paths '''
+  """download s3 bucket keys to specified paths"""
   for key, path in keys_and_paths.items():
     client.download_file(bucket, key, path)
 
 def keys_last_modified_in_range(keys, keys_last_modified, start_date, end_date):
-  ''' return list of s3 bucket keys that were last modified within date range '''
+  """return list of s3 bucket keys that were last modified within date range"""
   return [
     key for index, key in enumerate(keys)
     if keys_last_modified[index] >= start_date and
@@ -39,7 +39,7 @@ def keys_last_modified_in_range(keys, keys_last_modified, start_date, end_date):
   ]
 
 def list_access_log_keys(client, bucket, prefix, days):
-  '''Return access log keys and their last modified time,
+  """Return access log keys and their last modified time,
   for keys whose names start with any of the days specified.
 
   Access log key names start with the yyyy-mm-dd. For example:
@@ -53,7 +53,7 @@ def list_access_log_keys(client, bucket, prefix, days):
   We list:
   - foo/2023-02-21-
   - foo/2023-02-22-
-  '''
+  """
   keys = []
   keys_last_modified = []
   for day in days:
@@ -64,7 +64,7 @@ def list_access_log_keys(client, bucket, prefix, days):
   return keys, keys_last_modified
 
 def list_keys(client, bucket, prefix):
-  ''' list all keys in s3 bucket matching prefix '''
+  """list all keys in s3 bucket matching prefix"""
   keys = []
   keys_last_modified = []
   next_token = ''
@@ -87,7 +87,7 @@ def list_keys(client, bucket, prefix):
   return [keys, keys_last_modified]
 
 def map_keys_to_paths(keys, dest_dir):
-  ''' return mapping of s3 bucket keys to their dest paths '''
+  """return mapping of s3 bucket keys to their dest paths"""
   keys_and_paths = {}
   for key in keys:
     keys_and_paths[key] = os.path.join(dest_dir, key)

--- a/aws_s3_log_analyzer/s3.py
+++ b/aws_s3_log_analyzer/s3.py
@@ -1,16 +1,14 @@
 import boto3
 import os
 
+from aws_s3_log_analyzer.dates import date_range_to_days_list
 from aws_s3_log_analyzer.files import make_dirs
 
-def download(bucket, prefix, start_date, end_date, dest_dir):
-  ''' download s3 bucket keys that were last modified within date range '''
+def download_access_logs(bucket, prefix, start_date, end_date, dest_dir):
+  ''' download s3 access logs that were last modified within date range '''
   client = boto3.client('s3')
-  [keys, keys_last_modified] = list_keys(client, bucket, prefix)
-  wanted_keys = keys_last_modified_in_range(
-                  keys, keys_last_modified, start_date, end_date
-                )
-  download_keys(client, bucket, wanted_keys, dest_dir)
+  keys = list_access_log_keys(client, bucket, prefix, start_date, end_date)
+  download_keys(client, bucket, keys, dest_dir)
 
 def download_keys(client, bucket, keys, dest_dir):
   ''' download s3 bucket keys '''
@@ -31,6 +29,40 @@ def keys_last_modified_in_range(keys, keys_last_modified, start_date, end_date):
     if keys_last_modified[index] >= start_date and
       keys_last_modified[index] <= end_date
   ]
+
+def list_access_log_keys(client, bucket, prefix, start_date, end_date):
+  '''return list of keys under the specified S3 bucket/prefix holding S3 access logs
+  S3 creates a log file for every few access events.
+  So there can be thousands and thousands of files/keys under the prefix.
+  Listing them will take a long time.
+
+  Since the keys are named after their dates, for example:
+  2023-02-22-00-15-29-D5DCE8A086530745
+
+  We make the prefix more specific, listing fewer keys, which is faster.
+
+  For example, if we are given:
+  - prefix: foo/
+  - start_date: 2023-02-21...
+  - end_date: 2023-02-22...
+
+  We list only these prefixes:
+  - foo/2023-02-21-
+  - foo/2023-02-22-
+  '''
+  days = date_range_to_days_list(start_date, end_date)
+  keys = []
+  keys_last_modified = []
+  for day in days:
+    full_prefix = prefix + day + '-'
+    [day_keys, day_keys_last_modified] = list_keys(client, bucket, full_prefix)
+    keys += day_keys
+    keys_last_modified += day_keys_last_modified
+  # still check the keys' last modified date
+  filtered_keys = keys_last_modified_in_range(
+                  keys, keys_last_modified, start_date, end_date
+                )
+  return filtered_keys
 
 def list_keys(client, bucket, prefix):
   ''' list all keys in s3 bucket matching prefix '''

--- a/download_logs_from_s3.py
+++ b/download_logs_from_s3.py
@@ -6,7 +6,7 @@ from datetime import date as ddate, datetime, timedelta
 from pytz import UTC
 
 from aws_s3_log_analyzer.dates import string_to_utc_date
-from aws_s3_log_analyzer.s3 import download
+from aws_s3_log_analyzer.s3 import download_access_logs
 
 def parse_args():
   parser = argparse.ArgumentParser(
@@ -70,4 +70,4 @@ if start_date_obj > end_date_obj:
 
 dest_dir = dest_base_dir + '/' + s3_bucket
 
-download(s3_bucket, prefix, start_date_obj, end_date_obj, dest_dir)
+download_access_logs(s3_bucket, prefix, start_date_obj, end_date_obj, dest_dir)

--- a/download_logs_from_s3.py
+++ b/download_logs_from_s3.py
@@ -20,6 +20,13 @@ def parse_args():
     '''
   )
   parser.add_argument(
+    '--prefix',
+    default='/',
+    help='''
+    only look at log files under this prefix.
+    '''
+  )
+  parser.add_argument(
     '--start_date',
     default=datetime.now(tz=UTC) - timedelta(days=1),
     help='''
@@ -52,8 +59,8 @@ def parse_args():
 ######
 
 args = parse_args()
-s3_bucket, start_date, end_date, dest_base_dir  = (
-  args.s3_bucket, args.start_date, args.end_date, args.dest_base_dir
+s3_bucket, prefix, start_date, end_date, dest_base_dir  = (
+  args.s3_bucket, args.prefix, args.start_date, args.end_date, args.dest_base_dir
 )
 
 start_date_obj = string_to_utc_date(start_date)
@@ -63,4 +70,4 @@ if start_date_obj > end_date_obj:
 
 dest_dir = dest_base_dir + '/' + s3_bucket
 
-download(s3_bucket, start_date_obj, end_date_obj, dest_dir)
+download(s3_bucket, prefix, start_date_obj, end_date_obj, dest_dir)

--- a/test/fixtures/s3.py
+++ b/test/fixtures/s3.py
@@ -19,6 +19,16 @@ def expected_keys_last_modified():
   ]
 
 @pytest.fixture
+def mock_list_prefix():
+  def mock_list_keys(client, bucket, prefix):
+    return_values = [
+      [prefix + 'abc'],
+      [datetime.datetime(2023, 1, 23, 1, 17, 7, tzinfo=tzutc())]
+    ]
+    return return_values
+  return mock_list_keys
+
+@pytest.fixture
 def mock_s3_client():
   class mock_s3_client():
     def list_objects_v2(**kwargs):

--- a/test/test_dates.py
+++ b/test/test_dates.py
@@ -3,7 +3,19 @@ import pytest
 from datetime import datetime
 from pytz import UTC
 
-from aws_s3_log_analyzer.dates import string_to_utc_date
+from aws_s3_log_analyzer.dates import \
+  date_range_to_days_list, \
+  string_to_utc_date
+
+def describe_date_range_to_days_list():
+  def it_returns_the_in_range_days():
+    start_date = datetime.strptime('1990-01-01 01:01:01', '%Y-%m-%d %H:%M:%S')
+    start_date.replace(tzinfo=UTC)
+    end_date = datetime.strptime('1990-01-03 01:01:01', '%Y-%m-%d %H:%M:%S')
+    end_date.replace(tzinfo=UTC)
+    assert date_range_to_days_list(start_date, end_date) == [
+      '1990-01-01', '1990-01-02', '1990-01-03'
+    ]
 
 def describe_string_to_utc_date():
   def converts_string():

--- a/test/test_dates.py
+++ b/test/test_dates.py
@@ -18,12 +18,11 @@ def describe_date_range_to_days_list():
     ]
 
 def describe_string_to_utc_date():
-  def converts_string():
+  def it_converts_string():
     strx = '1990-01-01 01:01:01'
     date = datetime.strptime('1990-01-01 01:01:01', '%Y-%m-%d %H:%M:%S')
     date2 = date.replace(tzinfo=UTC)
     assert string_to_utc_date(strx) == date2
-
-  def does_not_convert_datetime_object():
+  def it_does_not_convert_datetime_object():
     date = datetime.now()
     assert string_to_utc_date(date) is date

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -13,11 +13,11 @@ from test.fixtures.sample_logs import \
   sample_logs_txt
 
 def describe_files():
-  def finds_them(sample_log_dir_path, sample_log_dir_files):
+  def it_finds_them(sample_log_dir_path, sample_log_dir_files):
     assert sorted(files(sample_log_dir_path)) == sorted(sample_log_dir_files)
 
 def describe_make_dirs():
-  def makes_nonexistent_dirs(mocker):
+  def it_makes_nonexistent_dirs(mocker):
     mocker.patch('os.path.exists', return_value=False)
     mocker.patch('os.makedirs')
     os_makedirs_spy = mocker.spy(os, "makedirs")
@@ -25,8 +25,7 @@ def describe_make_dirs():
     make_dirs(paths)
     assert os_makedirs_spy.call_count == 2
     os_makedirs_spy.assert_has_calls([mocker.call('foo'), mocker.call('bar')])
-
-  def skips_existent_dir(mocker):
+  def it_skips_existent_dir(mocker):
     mocker.patch('os.path.exists').side_effect = [False, True]
     mocker.patch('os.makedirs')
     os_makedirs_spy = mocker.spy(os, "makedirs")
@@ -36,12 +35,11 @@ def describe_make_dirs():
     os_makedirs_spy.assert_has_calls([mocker.call('foo')])
 
 def describe_read_files_in_dir():
-  def reads_them(sample_log_dir_path, sample_logs_txt):
+  def it_reads_them(sample_log_dir_path, sample_logs_txt):
     assert sorted(read_files_in_dir(sample_log_dir_path)) == sorted(sample_logs_txt)
 
 def describe_reads_path():
-  def reads_file(sample_log_file_path, sample_logs_txt):
+  def it_reads_file(sample_log_file_path, sample_logs_txt):
     assert read_path(sample_log_file_path) == sample_logs_txt
-
-  def reads_dir(sample_log_dir_path, sample_logs_txt):
+  def it_reads_dir(sample_log_dir_path, sample_logs_txt):
     assert sorted(read_path(sample_log_dir_path)) == sorted(sample_logs_txt)

--- a/test/test_logs.py
+++ b/test/test_logs.py
@@ -13,15 +13,15 @@ from test.fixtures.sample_logs import \
   sample_logs_txt_clean
 
 def describe_clean_log():
-  def cleans(sample_logs_txt, sample_logs_txt_clean):
+  def it_cleans(sample_logs_txt, sample_logs_txt_clean):
     result = [clean_log(log) for log in sample_logs_txt]
     assert result == sample_logs_txt_clean
 
 def describe_create_data_frame():
-  def creates_requester_key_df(sample_log_file_path, sample_logs_requester_object_day_df):
+  def it_creates_requester_key_df(sample_log_file_path, sample_logs_requester_object_day_df):
     df = create_data_frame(sample_log_file_path, ['requester-id', 's3-object-key'])
     assert df.equals(sample_logs_requester_object_day_df)
 
 def describe_s3_logs_to_csv_rows():
-  def converts(sample_log_file_path, sample_logs_csv):
+  def it_converts(sample_log_file_path, sample_logs_csv):
     assert s3_logs_to_csv_rows(sample_log_file_path) == sample_logs_csv

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -21,35 +21,33 @@ def describe_keys_last_modified_in_range():
   start_date = now - timedelta(days = 3)
   end_date = now - timedelta(days = 1)
 
-  def all_in_range():
+  def it_returns_correctly_when_all_in_range():
     keys_last_modified = [
       now - timedelta(days = 3),
       now - timedelta(days = 2),
       now - timedelta(days = 1)
     ]
     assert keys_last_modified_in_range(
-            keys, keys_last_modified, start_date, end_date
-           ) == keys
-
-  def none_in_range():
+      keys, keys_last_modified, start_date, end_date
+    ) == keys
+  def it_returns_correctly_when_none_in_range():
     keys_last_modified = [
       now - timedelta(days = 5),
       now - timedelta(days = 4),
       now
     ]
     assert keys_last_modified_in_range(
-            keys, keys_last_modified, start_date, end_date
-           ) == []
-
-  def some_in_range():
+      keys, keys_last_modified, start_date, end_date
+     ) == []
+  def it_returns_correctly_when_some_in_range():
     keys_last_modified = [
       now - timedelta(days = 4),
       now - timedelta(days = 2),
       now
     ]
     assert keys_last_modified_in_range(
-            keys, keys_last_modified, start_date, end_date
-           ) == ['bar']
+      keys, keys_last_modified, start_date, end_date
+     ) == ['bar']
 
 def describe_list_access_log_keys():
   def it_lists_keys_that_are_named_by_the_specified_days(mocker, mock_list_prefix):
@@ -79,17 +77,15 @@ def describe_list_keys():
     assert keys_last_modified == expected_keys_last_modified
 
 def describe_map_keys_to_paths():
-  def no_keys():
+  def it_maps_correctly_when_no_keys():
     keys = []
     dest_dir = './logs'
     assert map_keys_to_paths(keys, dest_dir) == {}
-
-  def one_key():
+  def it_maps_correctly_when_one_key():
     keys = ['foo']
     dest_dir = './logs'
     assert map_keys_to_paths(keys, dest_dir) == {'foo': './logs/foo'}
-
-  def two_keys():
+  def it_maps_correctly_when_two_keys():
     keys = ['foo', 'foo/bar']
     dest_dir = './logs'
     assert map_keys_to_paths(keys, dest_dir) == \

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -47,8 +47,8 @@ def describe_keys_last_modified_in_range():
            ) == ['bar']
 
 def describe_list_keys():
-  def gets_keys(expected_keys, expected_keys_last_modified, mock_s3_client):
-    [keys, keys_last_modified] = list_keys(mock_s3_client, None)
+  def it_lists_keys(expected_keys, expected_keys_last_modified, mock_s3_client):
+    [keys, keys_last_modified] = list_keys(mock_s3_client, 'foobucket', 'fooprefix')
     assert keys == expected_keys
     assert keys_last_modified == expected_keys_last_modified
 


### PR DESCRIPTION
- Improvements to S3 access log download.
  - Allow user to specify a prefix in the S3 bucket that holds access logs.
  - Do not list all keys under a bucket/prefix. Limit listing to only the keys whose names start with dates that fall within start and end dates specified by user.
- Style changes:
  - Docstrings use double quotes with no spaces around them.
  - Tests' function names start with `it_`.